### PR TITLE
Fix namespace to follow PSR-4

### DIFF
--- a/src/Tests/Interpolation/BilinearInterpolationTest.php
+++ b/src/Tests/Interpolation/BilinearInterpolationTest.php
@@ -9,7 +9,7 @@
  * with this source code in the file LICENSE.
  */
 
-namespace Runalyze\DEM\tests\Interpolation;
+namespace Runalyze\DEM\Tests\Interpolation;
 
 use Runalyze\DEM\Interpolation\BilinearInterpolation;
 


### PR DESCRIPTION
PSR-4 is not followed here as the namespace is with lowercase "t" in "tests" and the folder name is with uppercase "T".

When Composer v2 comes out, if PSR-4 is not followed autoloading will not work so I thought it would be a good time to fix this.

Thanks for the great package! Cheers! :slightly_smiling_face: 